### PR TITLE
Create LoopGen Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Koriym.Loop
 
-Converts database result sets into an entity list generator that is handy to use in views.
-
-The entity list can be iterated with information provided such as `isFirst`, `isLast`, etc. It provides similar functionality for native PHP as the loop processing provided by template engines such as Smarty and Twig.
+Koriym.Loop is a PHP library that converts various iterable data sets, such as database result sets, CSV files, or any other iterable structures, into an entity list generator. This makes it easy to use in views by providing looping information such as isFirst, isLast, index, and iteration, similar to the loop processing found in template engines like Twig.
 
 ## Usage
+
+## Basic Example
+
+The following example demonstrates how to use Koriym.Loop with a simple User class and a result set:
 
 ```php
 class User
@@ -15,7 +17,8 @@ class User
     ){}
 }
 
-$resultSet = [
+// Database result sets or csv content
+$resultSet = [ 
     ['id' => 1, 'name' => 'ray'],
     ['id' => 2, 'name' => 'bear'],
     ['id' => 3, 'name' => 'alps'],
@@ -28,7 +31,9 @@ foreach ($users as $user) {
 }
 ```
 
-Loop information is obtained from the array keys.
+### Loop information
+
+Loop information can be accessed from the array keys, providing details such as whether the current item is the first or last in the list:
 
 ```php
 /** @var Loop $loop */
@@ -42,7 +47,7 @@ foreach ($users as $loop => $user) {
 }
 ```
 
-`Loop`
+### Loop Properties
 
 | property  | type | Description            |
 | --------- | ---- | ---------------------- |
@@ -63,15 +68,31 @@ $dependencies = [
 $users = (new LoopGen)($resultSet, User::class, $dependencies);
 ```
 
-## Iterator
+## Iterator Support
 
-Iterator is supported as well as array.
+Koriym.Loop supports iterators as well as arrays. Here's an example using a CSV iterator:
 
 ```php
+class Row
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name
+    ){}
+}
+
+// Retrieve contents of csv file as list<Row>
 $csvIterator = new ogrrd\CsvIterator\CsvIterator($csvFilePath);
-/** @var list<User> $userList */
+/** @var list<Row> $csvRowList */
 $csvRowList = (new LoopGen)($csvIterator, Row::class);
-foreach ($csvRowList as $row) {
+
+foreach ($csvRowList as $loop => $row) {
+    if ($loop->isFirst) {
+        continue; // Skip header
+    }
     echo $row->name;
 }
 ```
+
+This library provides a flexible and convenient way to handle looping through result sets and other iterable data structures in PHP, with additional context information about the loop's state.
+

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -40,6 +40,7 @@
     </rule>
     <!-- Additional Rules -->
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamName" />
         <properties>
             <property name="annotationsGroups" type="array">
                 <element value="@param, @psalm-param, @phpstan-param"/>

--- a/src/LoopGen.php
+++ b/src/LoopGen.php
@@ -55,7 +55,6 @@ final class LoopGen implements LoopGenInterface
      *
      * @return T
      *
-     * @psalm-suppress MixedMethodCall
      * @SuppressWarnings("UnusedPrivateMethod")
      */
     private function newEntity(string $entity, array $elements)
@@ -64,6 +63,7 @@ final class LoopGen implements LoopGenInterface
             $elements = array_values($elements);
         }
 
+        /** @psalm-suppress MixedMethodCall */
         return new $entity(...$elements);
     }
 }

--- a/src/LoopGen.php
+++ b/src/LoopGen.php
@@ -55,7 +55,7 @@ final class LoopGen implements LoopGenInterface
      *
      * @return T
      *
-     * @SuppressWarnings("UnusedPrivateMethod")
+     * @SuppressWarnings("UnusedPrivateMethod") // This method is used in the __invoke method
      */
     private function newEntity(string $entity, array $elements)
     {

--- a/src/LoopGen.php
+++ b/src/LoopGen.php
@@ -6,7 +6,6 @@ namespace Koriym\Loop;
 
 use ArrayIterator;
 use Generator;
-use Iterator;
 
 use function array_values;
 use function is_array;
@@ -14,24 +13,15 @@ use function is_array;
 use const PHP_MAJOR_VERSION;
 
 /**
+ * Generate loops for a given set of elements
+ *
  * @template T of object
+ * @implements LoopGenInterface<T>
  */
-final class LoopGen
+final class LoopGen implements LoopGenInterface
 {
-    // phpcs:disable
     /**
-     * This function generates a loop for the given elements. It takes an iterator or an array of elements,
-     * a class-string entity, an optional array of extra parameters, and an optional factory callable.
-     * It returns a generator that yields a new Loop object for each element.
-     *
-     * @param Iterator<array-key, array<string, mixed>>|array<array<string, mixed>>  $elements
-     * @param class-string<T>              $entity
-     * @param array<string, mixed>         $extraParams
-     * @param callable(class-string, mixed...):T $factory
-     *
-     * @return Generator<Loop, T, mixed, void>
-     *
-     * @psalm-suppress ImplementedReturnTypeMismatch
+     * {@inheritDoc}
      */
     public function __invoke(
         // phpcs:enable

--- a/src/LoopGenInterface.php
+++ b/src/LoopGenInterface.php
@@ -23,8 +23,6 @@ interface LoopGenInterface
      * @param callable(class-string, mixed...):T                                    $factory
      *
      * @return Generator<Loop, T, mixed, void>
-     *
-     * @psalm-suppress ImplementedReturnTypeMismatch
      */
     public function __invoke($elements, string $entity, array $extraParams = [], ?callable $factory = null): Generator;
 }

--- a/src/LoopGenInterface.php
+++ b/src/LoopGenInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Loop;
+
+use Generator;
+use Iterator;
+
+/**
+ * @template T of object
+ */
+interface LoopGenInterface
+{
+    /**
+     * This function generates a loop for the given elements. It takes an iterator or an array of elements,
+     * a class-string entity, an optional array of extra parameters, and an optional factory callable.
+     * It returns a generator that yields a new Loop object for each element.
+     *
+     * @param Iterator<array-key, array<string, mixed>>|array<array<string, mixed>> $elements
+     * @param class-string<T>                                                       $entity
+     * @param array<string, mixed>                                                  $extraParams
+     * @param callable(class-string, mixed...):T                                    $factory
+     *
+     * @return Generator<Loop, T, mixed, void>
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
+     */
+    public function __invoke($elements, string $entity, array $extraParams = [], ?callable $factory = null): Generator;
+}

--- a/tests/LoopGenTest.php
+++ b/tests/LoopGenTest.php
@@ -100,4 +100,14 @@ class LoopGenTest extends TestCase
             $this->assertInstanceOf(DateTime::class, $item->date);
         }
     }
+
+    public function testEmptySets(): void
+    {
+        $list = (new LoopGen())(
+            [],
+            FakeUser::class,
+            ['date' => new DateTime('now')]
+        );
+        $this->assertCount(0, $list);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `Koriym.Loop` PHP library for converting iterable data sets into an entity list generator with loop information like `isFirst`, `isLast`, and index.
  - Added support for database result sets, CSV files, and other iterable structures.

- **Bug Fixes**
  - Updated `LoopGen` function to support iterable data sets and entity classes.
  - Enhanced `User` and `Row` classes with new constructor parameters and properties.

- **Tests**
  - Added `testEmptySets` method to ensure `LoopGen` handles empty data sets correctly.

- **Chores**
  - Updated `phpcs.xml` to exclude specific function comment rules for better code documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->